### PR TITLE
Update vite.config.ts to support ts aliases

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite';
+import { fileURLToPath } from 'url';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: '@', replacement: fileURLToPath(new URL('./src', import.meta.url)) },
+      { find: '@test-utils', replacement: fileURLToPath(new URL('./test-utils', import.meta.url)) }
+    ],
+  }
 });


### PR DESCRIPTION
Vite does not have the two typescript aliases configured, which might cause confusion when code editors type-sense these paths. Add the two aliases defined in tsconfig.json to vite.config.ts